### PR TITLE
Fix filename for partial HTML

### DIFF
--- a/lib/doc_my_routes/doc/config.rb
+++ b/lib/doc_my_routes/doc/config.rb
@@ -28,6 +28,7 @@ module DocMyRoutes
 
         @destination_dir = File.join(Dir.pwd, 'doc', 'api')
         @format = :html
+        @partial = false
 
         default_static_path = File.join(File.dirname(__FILE__), '..', '..',
                                         '..', 'etc')
@@ -45,6 +46,7 @@ module DocMyRoutes
         fail UnsupportedFormat,
           "The output format must be :html or :partial_format. It is #{@format}" \
           unless %i(html partial_html).include?(@format)
+        @partial = true
       end
 
       # Calculate the relative path of the CSS used
@@ -54,7 +56,8 @@ module DocMyRoutes
       end
 
       def index_file
-        File.join(@destination_dir, 'index.html')
+        filename = @partial ? 'index_partial.html' : 'index.html'
+        File.join(@destination_dir, filename)
       end
     end
   end

--- a/spec/system/output_spec.rb
+++ b/spec/system/output_spec.rb
@@ -32,10 +32,12 @@ describe DocMyRoutes do
     context 'when I run the generation' do
       subject do
         DocMyRoutes::Documentation.generate
-        Nokogiri::XML(File.open("#{tmp_dir}/index.html"))
+        Nokogiri::XML(File.open("#{tmp_dir}/#{output_file}.html"))
       end
 
       context 'using the default formatter' do
+        let(:output_file) { 'index' }
+
         it 'generates a valid HTML file' do
           expect(subject.children.size).to eq 2
           expect(subject.children[1].name).to eq('html')
@@ -43,6 +45,8 @@ describe DocMyRoutes do
       end
 
       context 'using the :partial_html formatter' do
+        let(:output_file) { 'index_partial' }
+
         before do
           DocMyRoutes.configure do |c|
             c.format = :partial_html


### PR DESCRIPTION
This patch closes #2 

When partial HTML is generated, it now creates a _index_partial.html_.
