### PR TITLE
Fixing the logger reference in RouteCollection

### DIFF
--- a/lib/doc_my_routes/doc/route_collection.rb
+++ b/lib/doc_my_routes/doc/route_collection.rb
@@ -20,7 +20,7 @@ module DocMyRoutes
           namespace = format('%-50s', app_routes.first.namespace)
           DocMyRoutes.logger.debug "Adding route to #{namespace} - #{app_name}"
 
-          app_routes.each { |rte| logger.debug " - #{rte}" }
+          app_routes.each { |rte| DocMyRoutes.logger.debug " - #{rte}" }
         end
       end
     end


### PR DESCRIPTION
There is a problem when using the default logger:

`undefined local variable or method `logger' for DocMyRoutes::RouteCollection:Class (NameError)`

That error can be fixed by using the full namespace for the DocMyRoutes logger.