### PR TITLE
Add documentation for Resources with the same classname

### DIFF
--- a/lib/doc_my_routes/doc/documentation.rb
+++ b/lib/doc_my_routes/doc/documentation.rb
@@ -31,7 +31,8 @@ module DocMyRoutes
 
     def generate_content
       routes.each do |resource, rts|
-        content[:main][:apis][resource_name(resource)] = rts.map(&:to_hash)
+        content[:main][:apis][resource_name(resource)] ||= []
+        content[:main][:apis][resource_name(resource)] += rts.map(&:to_hash)
       end
     end
 


### PR DESCRIPTION
This is an ever so slight rewrite of https://github.com/Workday/doc_my_routes/pull/12. For bookkeeping's sake, I'm including the same PR description as can be found in https://github.com/Workday/doc_my_routes/pull/12.

When there are two classes with the same name but in different modules, only the documentation for the routes in one of them is generated.

For example:

    require 'doc_my_routes'

    require 'sinatra/base'
    require 'rack'

    module Extra
      class Api < Sinatra::Base
        extend DocMyRoutes::Annotatable

        summary 'Extra summary'
        get '/' do
          'Extra content'
        end
      end
    end

    class Api < Sinatra::Base
      extend DocMyRoutes::Annotatable

      summary 'Api summary'
      get '/' do
        'API content'
      end
    end

    url_map = ::Rack::URLMap.new({ '/api' => Api.new, '/extra' => Extra::Api.new })

    DocMyRoutes.configure do |config|
      config.title = "My Application"
      config.destination_dir = '/tmp/doc_my_routes/'
    end

    DocMyRoutes::RouteCollection.log_routes

    DocMyRoutes::Documentation.generate