### PR TITLE
Add documentation for parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: ruby
 rvm:
   - 2.1.5
   - 2.1.7
-before_install: gem install bundler -v 1.10.5
+before_install: gem install bundler -v 1.15.0

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ class MyApp < Sinatra::Base
   notes 'Simple route that gets an ID and returns a string'
   produces 'text/plain'
   status_codes [200]
+  parameter :id, description: 'some ID'
   get '/:id' do |id|
     "Received #{id}"
   end

--- a/etc/css/base.css
+++ b/etc/css/base.css
@@ -248,7 +248,7 @@ table
 table td
 {
   border-top:1px solid #ccc;
-  padding:.5em .5em .5em 0;
+  padding:.5em 1.5em .5em 0;
 }
 
 thead
@@ -282,21 +282,4 @@ article.example
 {
   color:#555;
   margin:1em;
-}
-
-.required_parameter
-{
-  color:#a41e22;
-  font-size:0.7em;
-}
-
-.parameter_type
-{
-  font-size:0.8em;
-  font-weight:400;
-}
-
-.parameter_in
-{
-  color:#555;
 }

--- a/etc/css/base.css
+++ b/etc/css/base.css
@@ -283,3 +283,20 @@ article.example
   color:#555;
   margin:1em;
 }
+
+.required_parameter
+{
+  color:#a41e22;
+  font-size:0.7em;
+}
+
+.parameter_type
+{
+  font-size:0.8em;
+  font-weight:400;
+}
+
+.parameter_in
+{
+  color:#555;
+}

--- a/etc/partial.html.erb
+++ b/etc/partial.html.erb
@@ -48,12 +48,25 @@
                     <thead>
                       <tr>
                         <th>Parameter</th>
+                        <th>Description</th>
                       </tr>
                     </thead>
                     <tbody class="operation-params">
-                    <% route[:parameters].each do |param| %>
+                    <% route[:parameters].each do |param_name, param_options| %>
                       <tr>
-                        <td><%= param %></td>
+                        <td>
+                          <%= param_name %>
+                          <% if param_options[:required] %>
+                            <sup class="required_parameter">*required</sup>
+                          <% end %>
+                          <% if param_options[:type] %>
+                            <div class="parameter_type"><%= param_options[:type] %></div>
+                          <% end %>
+                          <% if param_options[:in] %>
+                            <div class="parameter_in">(<%= param_options[:in] %>)</div>
+                          <% end %>
+                        </td>
+                        <td><%= param_options[:description] %></td>
                       </tr>
                     <% end %>
                     </tbody>

--- a/etc/partial.html.erb
+++ b/etc/partial.html.erb
@@ -48,24 +48,19 @@
                     <thead>
                       <tr>
                         <th>Parameter</th>
+                        <th>Required</th>
+                        <th>Location</th>
+                        <th>Type</th>
                         <th>Description</th>
                       </tr>
                     </thead>
                     <tbody class="operation-params">
                     <% route[:parameters].each do |param_name, param_options| %>
                       <tr>
-                        <td>
-                          <%= param_name %>
-                          <% if param_options[:required] %>
-                            <sup class="required_parameter">*required</sup>
-                          <% end %>
-                          <% if param_options[:type] %>
-                            <div class="parameter_type"><%= param_options[:type] %></div>
-                          <% end %>
-                          <% if param_options[:in] %>
-                            <div class="parameter_in">(<%= param_options[:in] %>)</div>
-                          <% end %>
-                        </td>
+                        <td><%= param_name %></td>
+                        <td><%= param_options[:required] ? 'Yes' : 'No' %></td>
+                        <td><%= param_options[:in] %></td>
+                        <td><%= param_options[:type] %></td>
                         <td><%= param_options[:description] %></td>
                       </tr>
                     <% end %>

--- a/lib/doc_my_routes/doc/hash_helpers.rb
+++ b/lib/doc_my_routes/doc/hash_helpers.rb
@@ -1,0 +1,13 @@
+# Define error classes
+module DocMyRoutes
+  module HashHelpers
+    def deep_merge(first, second)
+      merger = proc { |key, f, s| f.is_a?(Hash) && s.is_a?(Hash) ? f.merge(s, &merger) : s }
+      first.merge(second, &merger)
+    end
+
+    def array_to_hash_keys(arr, default_value = {})
+      {}.tap { |hash| arr.each { |key| hash[key] = default_value } }
+    end
+  end
+end

--- a/lib/doc_my_routes/doc/hash_helpers.rb
+++ b/lib/doc_my_routes/doc/hash_helpers.rb
@@ -1,12 +1,12 @@
 # Define error classes
 module DocMyRoutes
   module HashHelpers
-    def deep_merge(first, second)
+    def self.deep_merge(first, second)
       merger = proc { |key, f, s| f.is_a?(Hash) && s.is_a?(Hash) ? f.merge(s, &merger) : s }
       first.merge(second, &merger)
     end
 
-    def array_to_hash_keys(arr, default_value = {})
+    def self.array_to_hash_keys(arr, default_value = {})
       {}.tap { |hash| arr.each { |key| hash[key] = default_value } }
     end
   end

--- a/lib/doc_my_routes/doc/hash_helpers.rb
+++ b/lib/doc_my_routes/doc/hash_helpers.rb
@@ -1,9 +1,12 @@
-# Define error classes
 module DocMyRoutes
+  # Define hash helpers for deep hash merge and transforming hash into array of keys
   module HashHelpers
-    def self.deep_merge(first, second)
-      merger = proc { |key, f, s| f.is_a?(Hash) && s.is_a?(Hash) ? f.merge(s, &merger) : s }
-      first.merge(second, &merger)
+    def self.deep_merge(first_hash, second_hash)
+      merger = proc do |key, first, second|
+        first.is_a?(Hash) && second.is_a?(Hash) ? first.merge(second, &merger) : second
+      end
+
+      first_hash.merge(second_hash, &merger)
     end
 
     def self.array_to_hash_keys(arr, default_value = {})

--- a/lib/doc_my_routes/doc/mixins/annotatable.rb
+++ b/lib/doc_my_routes/doc/mixins/annotatable.rb
@@ -87,6 +87,10 @@ module DocMyRoutes
       route_documentation.notes_ref = value
     end
 
+    def parameter(value, options = {})
+      route_documentation.add_parameter(value, options)
+    end
+
     private
 
     def track_route(resource, verb, route_pattern, conditions)

--- a/lib/doc_my_routes/doc/route.rb
+++ b/lib/doc_my_routes/doc/route.rb
@@ -23,6 +23,10 @@ module DocMyRoutes
       @documentation = documentation
     end
 
+    # We need to use deep merge as param_info method will return a hash for parameters
+    # with extracted information from the route path, and documentation might also have
+    # parameters with some more documentation and we don't want to loose extracted data
+    # from route path
     def to_hash
       HashHelpers.deep_merge({
         http_method: verb,

--- a/lib/doc_my_routes/doc/route.rb
+++ b/lib/doc_my_routes/doc/route.rb
@@ -24,7 +24,7 @@ module DocMyRoutes
     end
 
     def to_hash
-      deep_merge({
+      HashHelpers.deep_merge({
         http_method: verb,
         parameters: param_info,
         path: path

--- a/lib/doc_my_routes/doc/route_documentation.rb
+++ b/lib/doc_my_routes/doc/route_documentation.rb
@@ -3,12 +3,13 @@ module DocMyRoutes
   class RouteDocumentation
     attr_accessor :summary, :notes, :status_codes, :examples_regex, :hidden,
                   :produces, :notes_ref
-    attr_reader :examples
+    attr_reader :examples, :parameters
 
     def initialize
       @status_codes = { 200 => DocMyRoutes::StatusCodeInfo::STATUS_CODES[200] }
       @hidden = false
       @produces = []
+      @parameters = {}
     end
 
     # A route documentation object MUST have a summary, otherwise is not
@@ -25,12 +26,17 @@ module DocMyRoutes
         examples_regex: examples_regex,
         produces: produces,
         examples: examples,
+        parameters: parameters,
         hidden: hidden?
       }
     end
 
     def produces=(values)
       @produces = values.flatten.compact
+    end
+
+    def add_parameter(name, options)
+      @parameters[name] = options
     end
 
     def status_codes=(route_status_codes)

--- a/lib/doc_my_routes/version.rb
+++ b/lib/doc_my_routes/version.rb
@@ -1,4 +1,4 @@
 # DocMyRoutes version
 module DocMyRoutes
-  VERSION = '0.11.1'
+  VERSION = '0.12.0'
 end

--- a/spec/unit/doc_helpers_spec.rb
+++ b/spec/unit/doc_helpers_spec.rb
@@ -11,6 +11,7 @@ describe 'Route documentation' do
   DEFAULT_NOTES = 'Example notes'
   DEFAULT_NOTES_FILE = 'etc/example_notes.txt'
   DEFAULT_STATUS_CODES = [200, 401]
+  DEFAULT_PARAMETER_OPTIONS = { type: :integer, description: 'example parameter' }
 
   def mock_notes_file(content, path = 'notes.txt')
     mock_notes_path = File.expand_path(path)
@@ -25,6 +26,7 @@ describe 'Route documentation' do
     doc.summary = DEFAULT_SUMMARY
     doc.notes = DEFAULT_NOTES
     doc.status_codes = DEFAULT_STATUS_CODES
+    doc.add_parameter(:example_id, DEFAULT_PARAMETER_OPTIONS)
     doc
   end
 
@@ -34,9 +36,7 @@ describe 'Route documentation' do
                         "Actual object #{actual} doesn't have documentation"
 
       actual_docs = actual.documentation
-      actual_docs.summary == expected.summary && \
-        actual_docs.notes == expected.notes && \
-        actual_docs.status_codes == expected.status_codes
+      actual_docs.to_hash == expected.to_hash
     end
     description { "The route #{actual} doesn't match #{expected}" }
   end
@@ -63,7 +63,7 @@ describe 'Route documentation' do
     DocMyRoutes::RouteCollection.routes.clear
   end
 
-  context 'with summary, notes and status codes for a GET verb' do
+  context 'with summary, notes, parameter and status codes for a GET verb' do
     subject do
       key = DocMyRoutes::RouteCollection.routes.keys[0]
       DocMyRoutes::RouteCollection.routes[key]
@@ -75,13 +75,16 @@ describe 'Route documentation' do
         summary DEFAULT_SUMMARY
         notes DEFAULT_NOTES
         status_codes DEFAULT_STATUS_CODES
+        parameter :example_id, DEFAULT_PARAMETER_OPTIONS
         get '/api/example' do
         end
       }
     end
+
+    it_behaves_like 'a correctly tracked route'
   end
 
-  context 'with a summary, notes in an external file and status codes' do
+  context 'with a summary, notes in an external file, parameter and status codes' do
     def doc_route
       mock_notes_file(DEFAULT_NOTES, DEFAULT_NOTES_FILE)
       # Test class with only two routes GET and HEAD
@@ -89,6 +92,7 @@ describe 'Route documentation' do
         summary DEFAULT_SUMMARY
         notes_ref DEFAULT_NOTES_FILE
         status_codes DEFAULT_STATUS_CODES
+        parameter :example_id, DEFAULT_PARAMETER_OPTIONS
         post '/api/example_notes_file' do
         end
       }


### PR DESCRIPTION
  - adds new annotation method `parameter`
  - adds default `in` option set to `:path` and `:required` for
    parameters specified in the route path
  - adds documentation for parameter description from options:
     parameter name, description: 'parameter description'