### PR TITLE
Add support for sinatra/namespace and sinatra/multi_route

### DIFF
--- a/doc_my_routes.gemspec
+++ b/doc_my_routes.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test', '>= 0.6.2'
   spec.add_development_dependency 'rubocop', '>= 0.16'
   spec.add_development_dependency 'sinatra'
+  spec.add_development_dependency 'sinatra-contrib'
   spec.add_development_dependency 'nokogiri'
 end

--- a/spec/support/multirouteapp.rb
+++ b/spec/support/multirouteapp.rb
@@ -1,0 +1,24 @@
+require 'sinatra/base'
+require 'sinatra/multi_route'
+require 'doc_my_routes'
+
+module DocMyRoutes::Test
+  # App that utilises sinatra/multiroute
+  class MultirouteApp < Sinatra::Base
+    register Sinatra::MultiRoute
+
+    extend DocMyRoutes::Annotatable
+
+    get '/get_a', '/get_b' do
+      'GET A and GET B'
+    end
+
+    post '/post_a', '/post_b' do
+      'POST A and POST B'
+    end
+
+    route :get, :post, ['/get_or_post_a', '/get_or_post_b'] do
+      'GET/POST A and GET/POST B'
+    end
+  end
+end

--- a/spec/support/namespaceapp.rb
+++ b/spec/support/namespaceapp.rb
@@ -1,0 +1,37 @@
+require 'sinatra/base'
+require 'sinatra/namespace'
+require 'doc_my_routes'
+
+module DocMyRoutes::Test
+  # App with nested namespaces that uses DocMyRoutes
+  class NamespaceApp < Sinatra::Base
+    register Sinatra::Namespace
+
+    extend DocMyRoutes::Annotatable
+
+    DocMyRoutes.configure do |config|
+      config.title = 'Test application'
+      config.description = 'Example application to test DocMyRoutes'
+    end
+
+    namespace '/path_a' do
+      namespace '/subpath_1' do
+        summary 'Example GET'
+        notes 'Creates an example GET route that returns hello'
+        status_codes [200]
+        get '/sample_get' do
+          [200, {}, ['Hello from GET!']]
+        end
+      end
+
+      namespace '/subpath_2' do
+        summary 'Example POST'
+        notes 'Creates an example POST route that returns hello'
+        status_codes [200]
+        post '/sample_post' do
+          [200, {}, ['Hello from POST!']]
+        end
+      end
+    end
+  end
+end

--- a/spec/system/multiroute_spec.rb
+++ b/spec/system/multiroute_spec.rb
@@ -1,0 +1,46 @@
+# Encoding: UTF-8
+
+require 'rspec/mocks'
+require_relative '../spec_helper.rb'
+
+describe 'Given an application utilising sinatra/multi_route' do
+  include Rack::Test::Methods
+
+  before do
+    # The tests are only focused on the route created in each context
+    # without taking into consideration the real DocMyRoutes routes
+    DocMyRoutes::RouteCollection.routes.clear
+    reload_app('multirouteapp')
+  end
+
+  let(:app_name) { 'DocMyRoutes::Test::MultirouteApp' }
+
+  context 'its routes' do
+    subject { DocMyRoutes::RouteCollection.routes[app_name] }
+
+    it 'contain all specified verbs' do
+      expect(subject.size).to be(8)
+      expect(subject.map(&:verb)).to eq(
+        %w[GET GET POST POST GET GET POST POST]
+      )
+    end
+
+    it 'have correct route patterns' do
+      expect(subject.map(&:route_pattern)).to eq(
+        ['/get_a',
+         '/get_b',
+         '/post_a',
+         '/post_b',
+         '/get_or_post_a',
+         '/get_or_post_b',
+         '/get_or_post_a',
+         '/get_or_post_b']
+      )
+    end
+
+    it 'are not namespaced' do
+      # Namespaces are currently used for Sinatra Child Apps only
+      expect(subject.map(&:namespace)).to eq(Array.new(8, nil))
+    end
+  end
+end

--- a/spec/system/namespace_spec.rb
+++ b/spec/system/namespace_spec.rb
@@ -1,0 +1,35 @@
+# Encoding: UTF-8
+
+require 'rspec/mocks'
+require_relative '../spec_helper.rb'
+
+describe 'Given an application with nested namespaces' do
+  include Rack::Test::Methods
+
+  before do
+    # The tests are only focused on the route created in each context
+    # without taking into consideration the real DocMyRoutes routes
+    DocMyRoutes::RouteCollection.routes.clear
+    reload_app('namespaceapp')
+  end
+
+  let(:app_name) { 'DocMyRoutes::Test::NamespaceApp' }
+
+  context 'its routes' do
+    subject { DocMyRoutes::RouteCollection.routes[app_name] }
+
+    it 'contain only a GET and a POST route' do
+      expect(subject.size).to be(2)
+      expect(subject.map(&:verb)).to eq(['GET', 'POST'])
+    end
+
+    it 'have correct route patterns' do
+      expect(subject.map(&:route_pattern)).to eq(['/path_a/subpath_1/sample_get', '/path_a/subpath_2/sample_post'])
+    end
+
+    it 'are not namespaced' do
+      # Namespaces are currently used for Sinatra Child Apps only
+      expect(subject.map(&:namespace)).to eq([nil, nil])
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for apps that use the `sinatra/namespace` and `sinatra/multi_route` plugins from `sinatra-contrib`.